### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/taniumrest.json
+++ b/taniumrest.json
@@ -9,7 +9,7 @@
     "product_name": "Tanium REST",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "license": "Copyright (c) 2019-2025 Splunk Inc.",
     "latest_tested_versions": [


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)