### PR TITLE
Fix python_version format

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format

--- a/taniumrest.json
+++ b/taniumrest.json
@@ -9,10 +9,7 @@
     "product_name": "Tanium REST",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "license": "Copyright (c) 2019-2025 Splunk Inc.",
     "latest_tested_versions": [


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)